### PR TITLE
fix: convert findTagInTree from recursive to iterative DFS

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -82,11 +82,13 @@ export default function (pi: ExtensionAPI) {
     });
 
     // Helper: Check if a tag name already exists in the tree
+    // Iterative DFS to avoid call stack overflows on deep histories.
     const findTagInTree = (sm: SessionManager, nodes: SessionTreeNode[], tagName: string): string | null => {
-        for (const n of nodes) {
+        const stack: SessionTreeNode[] = [...nodes];
+        while (stack.length > 0) {
+            const n = stack.pop()!;
             if (sm.getLabel(n.entry.id) === tagName) return n.entry.id;
-            const r = findTagInTree(sm, n.children, tagName);
-            if (r) return r;
+            if (n.children?.length) stack.push(...n.children);
         }
         return null;
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,12 +83,17 @@ export default function (pi: ExtensionAPI) {
 
     // Helper: Check if a tag name already exists in the tree
     // Iterative DFS to avoid call stack overflows on deep histories.
+    // Push children in reverse order to preserve left-to-right pre-order semantics.
     const findTagInTree = (sm: SessionManager, nodes: SessionTreeNode[], tagName: string): string | null => {
-        const stack: SessionTreeNode[] = [...nodes];
+        const stack: SessionTreeNode[] = [...nodes].reverse();
         while (stack.length > 0) {
             const n = stack.pop()!;
             if (sm.getLabel(n.entry.id) === tagName) return n.entry.id;
-            if (n.children?.length) stack.push(...n.children);
+            if (n.children?.length) {
+                for (let i = n.children.length - 1; i >= 0; i--) {
+                    stack.push(n.children[i]);
+                }
+            }
         }
         return null;
     };


### PR DESCRIPTION
## Problem

`context_tag` throws `Maximum call stack size exceeded` on deep session trees with many branches/squashes.

Closes #19

## Root Cause

`findTagInTree` uses recursive DFS, which overflows the call stack:

```typescript
const findTagInTree = (sm, nodes, tagName) => {
    for (const n of nodes) {
        if (sm.getLabel(n.entry.id) === tagName) return n.entry.id;
        const r = findTagInTree(sm, n.children, tagName); // ← recursive
        if (r) return r;
    }
    return null;
};
```

## Fix

Convert to iterative DFS — same pattern already used in `resolveTargetId` in this same file, which has the comment: *"Iterative DFS to avoid call stack overflows on deep histories."*

```typescript
const findTagInTree = (sm, nodes, tagName) => {
    const stack = [...nodes];
    while (stack.length > 0) {
        const n = stack.pop();
        if (sm.getLabel(n.entry.id) === tagName) return n.entry.id;
        if (n.children?.length) stack.push(...n.children);
    }
    return null;
};
```

## Testing

- Verified on Pi 0.74.0 with deep session trees (many branches/squashes)
- `context_tag` works without stack overflow after the fix
- Same search semantics (finds existing tags, returns null if not found)