### PR TITLE
fix(skill): quote context-management description to fix YAML parse error

### DIFF
--- a/skills/context-management/SKILL.md
+++ b/skills/context-management/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: context-management
-description: Use this skill for multi-turn, phased, or noisy work: research/reading, debugging, plan-then-execute, retries/pivots, background or asynchronous work, handoffs, user decisions, task switching, repeated items, or repeated progress checks. It keeps the conversation as a clean working set with checkpoints, timeline review, and compaction at continuation boundaries. Always use when resuming after context compaction or when a long phase reaches a decision, handoff, validation, or task-switch boundary. Usually skip simple one-shot tasks.
+description: "Use this skill for multi-turn, phased, or noisy work: research/reading, debugging, plan-then-execute, retries/pivots, background or asynchronous work, handoffs, user decisions, task switching, repeated items, or repeated progress checks. It keeps the conversation as a clean working set with checkpoints, timeline review, and compaction at continuation boundaries. Always use when resuming after context compaction or when a long phase reaches a decision, handoff, validation, or task-switch boundary. Usually skip simple one-shot tasks."
 ---
 
 # Context Management


### PR DESCRIPTION
## Summary

Quote the `description` value in `skills/context-management/SKILL.md` frontmatter so the skill loads cleanly.

## Rationale

The unquoted description contained `work: research`, whose `: ` made the YAML parser treat it as a nested mapping under `description`, which is illegal in a compact mapping. The host agent failed to load the skill with:

```
Nested mappings are not allowed in compact mappings at line 2, column 14
```

Wrapping the value in double quotes matches the convention used by other installed skills.

## Verification

```sh
python3 -c "
import re, yaml
txt = open('skills/context-management/SKILL.md').read()
m = re.match(r'^---\n(.*?\n)---\n', txt, re.S)
fm = yaml.safe_load(m.group(1))
print('OK:', fm['name'], '|', fm['description'][:60], '...')
"
```

Result: `OK: context-management | Use this skill for multi-turn, phased, or noisy work: resear ...`
